### PR TITLE
Extending/correcting stimulation helper

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -44,6 +44,11 @@ jobs:
               if: steps.cache-elm.outputs.cache-hit != 'true'
               run: yarn build
 
+            # If we don't need to build, then at least run `gen`
+            - name: Build project
+              if: steps.cache-elm.outputs.cache-hit == 'true'
+              run: yarn elm-pages gen
+
             - name: Add elm-review, elm and elm-format to path
               run: yarn bin >> $GITHUB_PATH
 

--- a/app/Route/Index.elm
+++ b/app/Route/Index.elm
@@ -1845,7 +1845,6 @@ viewOrgasmButtons : PlayerModel -> List (Element PlayerMsg)
 viewOrgasmButtons model =
     [ el [ Font.bold, Ui.widthMin 300 ] (text "Am I Having an Orgasm? (Update at the START of your turn)")
     , [ ( True
-        , ""
         , "At the end of your turn, apply any Periodic effects. Then compare Satiation and Craving. If Satiation > Craving, -"
             ++ String.fromInt (Persona.levelBonus model.persona)
             ++ " Craving, -"
@@ -1861,7 +1860,6 @@ viewOrgasmButtons model =
             ++ " Sensitivity."
         )
       , ( False
-        , ""
         , "At the end of your turn, apply any Periodic effects. Then compare Satiation and Craving. If Satiation > Craving, -"
             ++ String.fromInt (Persona.levelBonus model.persona)
             ++ " Craving, -"
@@ -1878,8 +1876,8 @@ viewOrgasmButtons model =
     ]
 
 
-viewOrgasmButton : PlayerModel -> ( Orgasm, String, String ) -> Element PlayerMsg
-viewOrgasmButton model ( name, description, consequence ) =
+viewOrgasmButton : PlayerModel -> ( Orgasm, String ) -> Element PlayerMsg
+viewOrgasmButton model ( name, consequence ) =
     let
         selected : Bool
         selected =
@@ -1900,11 +1898,8 @@ viewOrgasmButton model ( name, description, consequence ) =
                 Just (SelectOrgasm (Just name))
         , label =
             Theme.column [ alignTop ]
-                (paragraph []
-                    [ el [ Font.bold ] (text (orgasmToString name))
-                    , text " "
-                    , text description
-                    ]
+                (paragraph [ Font.bold ]
+                    [ text (orgasmToString name) ]
                     :: Theme.viewMarkdown consequence
                 )
         }

--- a/app/Route/Index.elm
+++ b/app/Route/Index.elm
@@ -1675,7 +1675,7 @@ viewStimulationResolve player =
                             ++ ". Make sure to re-roll the Ardor check for each new source of Stimulation!"
 
                     Nothing ->
-                        "To calculate Intensity, roll an Ardor check with the Status Checks dice below."
+                        "To calculate Intensity, roll an Ardor check with the Status Checks dice."
           in
           text content
         ]

--- a/app/Route/Index.elm
+++ b/app/Route/Index.elm
@@ -1682,12 +1682,7 @@ viewStimulationResolve player =
     , paragraph
         [ Theme.padding
         ]
-        [ let
-            content : String
-            content =
-                "Total Stat Changes: "
-          in
-          text content
+        [ text "Total Stat Changes: "
         ]
     , paragraph
         [ Theme.padding

--- a/app/Route/Index.elm
+++ b/app/Route/Index.elm
@@ -1742,25 +1742,19 @@ viewStimulationResolve player =
         [ Theme.padding
         ]
         [ let
-            content : String
-            content =
-                let
-                    idealStimulation : Int
-                    idealStimulation =
-                        player.persona.ardor + meters.erogeny
+            idealStimulation : Int
+            idealStimulation =
+                player.persona.ardor + meters.erogeny
 
-                    overstimulation : Int
-                    overstimulation =
-                        if meters.stimulation <= idealStimulation then
-                            0
+            overstimulation : Int
+            overstimulation =
+                if meters.stimulation <= idealStimulation then
+                    0
 
-                        else
-                            max 0 (meters.stimulation - idealStimulation - meters.contour)
-                in
-                "Sensitivity: +"
-                    ++ String.fromInt overstimulation
+                else
+                    max 0 (meters.stimulation - idealStimulation - meters.contour)
           in
-          text content
+          text ("Sensitivity: +" ++ String.fromInt overstimulation)
         ]
     , paragraph
         [ Theme.padding

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "elm-optimize-level-2": "^0.3.5",
         "elm-pages": "^3.0.24",
         "elm-review": "^2.13.3",
-        "elm-test-rs": "^3.0.0-5",
+        "elm-test-rs": "^3.0.1-0",
         "lamdera": "^0.19.1-1.3.2",
         "vite": "^6.1.6"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -262,35 +262,35 @@
   resolved "https://registry.yarnpkg.com/@lamdera/compiler-win32-x64/-/compiler-win32-x64-0.19.1-1.3.2.tgz#7a09845a1f54ebfc263133b7a2cea9723ae295fb"
   integrity sha512-t/J3H3U6AZxAvdfB3XiH9ABcDSaNFoHF8tx2UKlgvn0yTV6azxrZanpsrmijDvdr038ktlVw7WFkiclxSST8CQ==
 
-"@mattpiz/elm-test-rs-darwin-arm64@3.0.0-1":
-  version "3.0.0-1"
-  resolved "https://registry.yarnpkg.com/@mattpiz/elm-test-rs-darwin-arm64/-/elm-test-rs-darwin-arm64-3.0.0-1.tgz#fe2abeb2b472b76242b0e8b69b5d5a18e97f20d1"
-  integrity sha512-+8pzcj2CK8NUElWvI4NUwCtn1doLk05NjFRXS9nUluGzgoImy9wwQPLtla5DWgdYOL70UufkwfxJN+0qaQMEpg==
+"@mattpiz/elm-test-rs-darwin-arm64@3.0.1-0":
+  version "3.0.1-0"
+  resolved "https://registry.yarnpkg.com/@mattpiz/elm-test-rs-darwin-arm64/-/elm-test-rs-darwin-arm64-3.0.1-0.tgz#f11ef5a1d47a58680386a01903a9b1f7b1558565"
+  integrity sha512-P9T1XhCgMnKCVaWl41YHvauXh5kDNEIDQyztk/XQTKLj3dA/T9wQ2rOpYrzCptQaLE0W+7yCayLLcWjpKmDm2w==
 
-"@mattpiz/elm-test-rs-darwin-x64@3.0.0-0":
-  version "3.0.0-0"
-  resolved "https://registry.yarnpkg.com/@mattpiz/elm-test-rs-darwin-x64/-/elm-test-rs-darwin-x64-3.0.0-0.tgz#26b0cc9c9543b58a7f03bac958ba2652e8f540a3"
-  integrity sha512-PfUELK7y9UpeZnvKeJBSPbuCbb1I3T0ptZUOnjVIWvAQmg3iov6I79PD2OEP9NtP0iepj+2v2BtgbmZlVrXIZg==
+"@mattpiz/elm-test-rs-darwin-x64@3.0.1-0":
+  version "3.0.1-0"
+  resolved "https://registry.yarnpkg.com/@mattpiz/elm-test-rs-darwin-x64/-/elm-test-rs-darwin-x64-3.0.1-0.tgz#c829955b6fd77bf28a9384a091b1cf43fccbee71"
+  integrity sha512-JEsw1bBHVLeZ9ZqpAF10iaDhcaT5f1BYo+lOrUTxqj7X4s2/aQXoAOYoh7p2i0M689ZQoJvJlw0DPdzOuxWUqA==
 
-"@mattpiz/elm-test-rs-linux-arm64@3.0.0-0":
-  version "3.0.0-0"
-  resolved "https://registry.yarnpkg.com/@mattpiz/elm-test-rs-linux-arm64/-/elm-test-rs-linux-arm64-3.0.0-0.tgz#f3e95983a4cb405d3b09c29ae8b668dc02413864"
-  integrity sha512-BdfQDWtVUFM1NMPa5U5lBKT3gtDSP7KpypdK+R0jRBx51382t5VA5Byb+2Nzc7aXgS6LA1/nvNRtq/jO7Aj2uw==
+"@mattpiz/elm-test-rs-linux-arm64@3.0.1-0":
+  version "3.0.1-0"
+  resolved "https://registry.yarnpkg.com/@mattpiz/elm-test-rs-linux-arm64/-/elm-test-rs-linux-arm64-3.0.1-0.tgz#2f7d87b4a4f69ec13e94c5a5d5e17ddda4846f2f"
+  integrity sha512-3A/1iRrG7itGxwUnXUmS9M9isoNjMhm4yE8rHu2om0xWX/+S+2g+0Dl++ZXEAtm5c+t5F8dbYvi0wA8G7oidXQ==
 
-"@mattpiz/elm-test-rs-linux-arm@3.0.0-0":
-  version "3.0.0-0"
-  resolved "https://registry.yarnpkg.com/@mattpiz/elm-test-rs-linux-arm/-/elm-test-rs-linux-arm-3.0.0-0.tgz#9ed4ee3eebb280cd90761738d06bfb4017e23d66"
-  integrity sha512-VVFq5horhAldLLmz/P2ljLArJkZuuzpjIUVo9KIPA15euesAxM0lzUnj5Bag9kbjZz4T6/YKToXnaxdDdwcitg==
+"@mattpiz/elm-test-rs-linux-arm@3.0.1-0":
+  version "3.0.1-0"
+  resolved "https://registry.yarnpkg.com/@mattpiz/elm-test-rs-linux-arm/-/elm-test-rs-linux-arm-3.0.1-0.tgz#e9be0b31cdce04f16c99e0d00b090250e30bba5c"
+  integrity sha512-nBF348Qs4ZTh1KhSzceHOZrZ0aZUF2r6Su/ggudzzeV9Sx7oW4K3EEx+3tZ5L8ZrAQjpbZ7iVK9UOZekWoXsOw==
 
-"@mattpiz/elm-test-rs-linux-x64@3.0.0-0":
-  version "3.0.0-0"
-  resolved "https://registry.yarnpkg.com/@mattpiz/elm-test-rs-linux-x64/-/elm-test-rs-linux-x64-3.0.0-0.tgz#ccaee2191358fe9b5daad6ffcf0d58c3e01092dd"
-  integrity sha512-RfOs3KEyPn0yEHjMjka3R99SdR/TtjgnjSsYahLL1mVUaWOHEcdr86iU6CpWScVtY2jMNQLaeudXOcBm6lXIsQ==
+"@mattpiz/elm-test-rs-linux-x64@3.0.1-0":
+  version "3.0.1-0"
+  resolved "https://registry.yarnpkg.com/@mattpiz/elm-test-rs-linux-x64/-/elm-test-rs-linux-x64-3.0.1-0.tgz#39edcd8e123a9abd65dac4ffe96f83256fe484d2"
+  integrity sha512-MCRdBazLDEu2GH4yASzTa3nngCPnKuf3KDjXHG1Oio301a3MTQOntOtniLwnEd/Je6wP30ff/WuOHlSloQWQjQ==
 
-"@mattpiz/elm-test-rs-win32-x64@3.0.0-0":
-  version "3.0.0-0"
-  resolved "https://registry.yarnpkg.com/@mattpiz/elm-test-rs-win32-x64/-/elm-test-rs-win32-x64-3.0.0-0.tgz#77f5d2adfe9a0dc864d6adfc229b44b2eb613c2a"
-  integrity sha512-7Vr74820XFPwUNrpZVybStPlCTyAjthgnUel23j3fJB2yDm9ydbBSPvLCmngqzkZBAnpX8eruUqDphTx+mR28Q==
+"@mattpiz/elm-test-rs-win32-x64@3.0.1-0":
+  version "3.0.1-0"
+  resolved "https://registry.yarnpkg.com/@mattpiz/elm-test-rs-win32-x64/-/elm-test-rs-win32-x64-3.0.1-0.tgz#80d5ad27fb28932d6277797d67d072dd8e138c30"
+  integrity sha512-GIoHBMGrZnit4evzCNNmGFbjKOBwl+EdBwUcmfEbM626aFNAIDaORQGXFJPKBKv/ujPTzAlXemBnX4jjjpYu3w==
 
 "@netlify/functions@^2.8.2":
   version "2.8.2"
@@ -1349,17 +1349,17 @@ elm-review@^2.13.3:
   resolved "https://registry.yarnpkg.com/elm-solve-deps-wasm/-/elm-solve-deps-wasm-2.0.0.tgz#8214705876fbcd9789cf6ab2db45ec781b5c1234"
   integrity sha512-11OV8FgB9qsth/F94q2SJjb1MoEgbworSyNM1L+YlxVoaxp7wtWPyA8cNcPEkSoIKG1B8Tqg68ED1P6dVamHSg==
 
-elm-test-rs@^3.0.0-5:
-  version "3.0.0-5"
-  resolved "https://registry.yarnpkg.com/elm-test-rs/-/elm-test-rs-3.0.0-5.tgz#b5d300b6585cff60fcae29157d52081281b728e8"
-  integrity sha512-efTPM54Ly7gm6zfECCYxfueP4TOVrMudae2eturtMBAvp5rlFOkWUL+7VHAsd4AjCvMNw5h7qD+c/RqQDhAH9Q==
+elm-test-rs@^3.0.1-0:
+  version "3.0.1-0"
+  resolved "https://registry.yarnpkg.com/elm-test-rs/-/elm-test-rs-3.0.1-0.tgz#7424007d38a4606568706eaab405c70950e55b49"
+  integrity sha512-mAYDM+h6dsibdt5iASuUAX9zj5LSmyXGne1T0ll7Mt8YjZ5FbXf+Ca6Iytx90YwsdsJjU4aGnEswTfB8MpW1hQ==
   optionalDependencies:
-    "@mattpiz/elm-test-rs-darwin-arm64" "3.0.0-1"
-    "@mattpiz/elm-test-rs-darwin-x64" "3.0.0-0"
-    "@mattpiz/elm-test-rs-linux-arm" "3.0.0-0"
-    "@mattpiz/elm-test-rs-linux-arm64" "3.0.0-0"
-    "@mattpiz/elm-test-rs-linux-x64" "3.0.0-0"
-    "@mattpiz/elm-test-rs-win32-x64" "3.0.0-0"
+    "@mattpiz/elm-test-rs-darwin-arm64" "3.0.1-0"
+    "@mattpiz/elm-test-rs-darwin-x64" "3.0.1-0"
+    "@mattpiz/elm-test-rs-linux-arm" "3.0.1-0"
+    "@mattpiz/elm-test-rs-linux-arm64" "3.0.1-0"
+    "@mattpiz/elm-test-rs-linux-x64" "3.0.1-0"
+    "@mattpiz/elm-test-rs-win32-x64" "3.0.1-0"
 
 emoji-regex@^8.0.0:
   version "8.0.0"


### PR DESCRIPTION
Extending and correcting logic for the stimulation helper. Also moved status checks to directly below Notes.

I would like to make the results display cleaner (merge the four separate paragraphs) and possibly create an inline 'stimulation ardor check die' similar to the 'valiant moxie check die', but I mostly do not know how to work with the formatting. 

It might also be nice if we could make sections collapsible as the screen is getting kind of busy with my new additional sections.